### PR TITLE
Adds compatibility for older projects

### DIFF
--- a/client/ayon_core/pipeline/load/utils.py
+++ b/client/ayon_core/pipeline/load/utils.py
@@ -721,12 +721,17 @@ def get_representation_path(representation, root=None):
 
     """
     if root is None:
-        from ayon_core.pipeline import get_current_project_name, Anatomy
+        try:
+            from ayon_core.pipeline import get_current_project_name, Anatomy
 
-        anatomy = Anatomy(get_current_project_name())
-        return get_representation_path_with_anatomy(
-            representation, anatomy
-        )
+            anatomy = Anatomy(get_current_project_name())
+            return get_representation_path_with_anatomy(
+                representation, anatomy
+            )
+        except Exception:
+            # INCO patch, fall back to registered_root if anatomy path fails
+            from ayon_core.pipeline import registered_root
+            root = registered_root()
 
     def path_from_representation():
         try:

--- a/client/ayon_core/pipeline/load/utils.py
+++ b/client/ayon_core/pipeline/load/utils.py
@@ -637,6 +637,40 @@ def _fix_representation_context_compatibility(repre_context):
     if isinstance(udim, list):
         repre_context["udim"] = udim[0]
 
+    # INCO patch
+    # convert OpenPype subset to Ayon product
+    old_product = repre_context.get("subset")
+    new_product = repre_context.get("product")
+    if old_product is not None and new_product is None:
+        repre_context["product"] = {
+            "name": repre_context.get("subset"),
+            "type": repre_context.get("family"),
+        }
+
+    # INCO patch
+    # convert OpenPype asset to Ayon folder,
+    # assumes Shot or Asset type
+    old_folder = repre_context.get("asset")
+    new_folder = repre_context.get("folder")
+    if old_folder is not None and new_folder is None:
+        hierarchy = repre_context.get("hierarchy")
+        asset = repre_context.get("asset")
+        parents = []
+        path = ""
+        type = "Shot"
+        if hierarchy is not None:
+            hierarchy = hierarchy.strip("/")
+            parents = hierarchy.split("/")
+            path = f"/{hierarchy}/{asset}"
+            if "asset" in hierarchy.lower():
+                type = "Asset"
+        repre_context["folder"] = {
+            "name": asset,
+            "parents": parents,
+            "path": path,
+            "type": type
+        }
+
 
 def get_representation_path_from_context(context):
     """Preparation wrapper using only context as a argument"""


### PR DESCRIPTION
Adds compatibility for older project structures by converting OpenPype subset/asset to Ayon product/folder structures when the new keys are missing from the representation context.

This ensures that older projects using the OpenPype naming conventions can be properly loaded within the Ayon ecosystem.